### PR TITLE
make Bash scripts more portable by using `#!/usr/bin/env bash` as the "shebang"

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # A build script for the release version of the Threema Android app.
 #  _____ _

--- a/scripts/generate-protobuf.sh
+++ b/scripts/generate-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # A script to verify that a locally compiled APK matches the released APK.
 #  _____ _


### PR DESCRIPTION
Make Bash scripts more portable by using `#!/usr/bin/env bash` as the "shebang", as not all systems that have Bash place it at `/bin/bash`. (E.g., `/bin/bash` won't work out-of-the-box on [NixOS](https://nixos.org/).)

See [this answer](https://stackoverflow.com/a/10383546/674064) to "What is the preferred Bash shebang?" and note that your existing `./gradlew` already leads by example: https://github.com/threema-ch/threema-android/blob/c3eb92a10166a9912056cfcd8f81f4df9c07f835/gradlew#L1

## Description

Replace `#!/bin/bash` with `#!/usr/bin/env bash` for all three Bash scripts in `./scripts/`

## Checklist

<!-- Please check the items that apply. -->

- [x] I've signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [x] All changes in this pull request were ~~created~~ _made_ by me, ~~I own the full copyright for all these changes~~
- [ ] These changes are sufficiently non-trivial to warrant copyright protection ([IANAL](https://en.wikipedia.org/wiki/IANAL);[TINLA](https://en.wikipedia.org/wiki/TINLA))
- [x] nos esse quasi nanos gigantum humeris insidentes