### PR TITLE
Adds possibility to edit caption before sharing it alongside media

### DIFF
--- a/app/src/main/java/ch/threema/app/activities/MediaViewerActivity.java
+++ b/app/src/main/java/ch/threema/app/activities/MediaViewerActivity.java
@@ -65,6 +65,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.viewpager.widget.PagerAdapter;
 import ch.threema.app.R;
 import ch.threema.app.ThreemaApplication;
+import ch.threema.app.dialogs.ExpandableTextEntryDialog;
 import ch.threema.app.emojis.EmojiMarkupUtil;
 import ch.threema.app.fragments.mediaviews.AudioViewFragment;
 import ch.threema.app.fragments.mediaviews.FileViewFragment;
@@ -92,10 +93,13 @@ import ch.threema.base.ThreemaException;
 import ch.threema.storage.models.AbstractMessageModel;
 import ch.threema.storage.models.DistributionListMessageModel;
 import ch.threema.storage.models.GroupMessageModel;
+import ch.threema.storage.models.MessageModel;
 import ch.threema.storage.models.MessageType;
 
 
-public class MediaViewerActivity extends ThreemaToolbarActivity {
+public class MediaViewerActivity extends ThreemaToolbarActivity implements
+	ExpandableTextEntryDialog.ExpandableTextEntryDialogClickListener {
+
 	private static final Logger logger = LoggerFactory.getLogger(MediaViewerActivity.class);
 
 	private static final int PERMISSION_REQUEST_SAVE_MESSAGE = 1;
@@ -439,11 +443,25 @@ public class MediaViewerActivity extends ThreemaToolbarActivity {
 
 	private void shareMedia() {
 		AbstractMessageModel messageModel = this.getCurrentMessageModel();
+		ExpandableTextEntryDialog alertDialog = ExpandableTextEntryDialog.newInstance(
+			getString(R.string.share_image),
+			R.string.add_caption_hint, messageModel.getCaption(),
+			R.string.send, R.string.cancel, true);
+		alertDialog.setData(messageModel);
+		alertDialog.show(getSupportFragmentManager(), null);
+	}
+
+	@Override
+	public void onYes(String tag, Object data, String text) {
+		AbstractMessageModel messageModel = (MessageModel) data;
 		Uri shareUri = fileService.copyToShareFile(messageModel, currentMediaFile);
 		messageService.shareMediaMessages(this,
-				new ArrayList<>(Collections.singletonList(messageModel)),
-				new ArrayList<>(Collections.singletonList(shareUri)));
+			new ArrayList<>(Collections.singletonList(messageModel)),
+			new ArrayList<>(Collections.singletonList(shareUri)), text);
 	}
+
+	@Override
+	public void onNo(String tag) {}
 
 	public void viewMediaInGallery() {
 		AbstractMessageModel messageModel = this.getCurrentMessageModel();

--- a/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
+++ b/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
@@ -88,6 +88,10 @@ public class ExpandableTextEntryDialog extends ThreemaDialogFragment {
 		object = o;
 	}
 
+	public void setCallback(ExpandableTextEntryDialogClickListener callback) {
+		this.callback = callback;
+	}
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);

--- a/app/src/main/java/ch/threema/app/services/MessageService.java
+++ b/app/src/main/java/ch/threema/app/services/MessageService.java
@@ -193,7 +193,7 @@ public interface MessageService {
 	 */
 	long getTotalMessageCount();
 
-	boolean shareMediaMessages(Context context, ArrayList<AbstractMessageModel> models, ArrayList<Uri> shareFileUris);
+	boolean shareMediaMessages(Context context, ArrayList<AbstractMessageModel> models, ArrayList<Uri> shareFileUris, String caption);
 	boolean viewMediaMessage(Context context, AbstractMessageModel model, Uri uri);
 	boolean shareTextMessage(Context context, AbstractMessageModel model);
 	AbstractMessageModel getMessageModelFromId(int id, String type);

--- a/app/src/main/java/ch/threema/app/services/MessageServiceImpl.java
+++ b/app/src/main/java/ch/threema/app/services/MessageServiceImpl.java
@@ -3042,7 +3042,7 @@ public class MessageServiceImpl implements MessageService {
 	}
 
 	@Override
-	public boolean shareMediaMessages(final Context context, ArrayList<AbstractMessageModel> models, ArrayList<Uri> shareFileUris) {
+	public boolean shareMediaMessages(final Context context, ArrayList<AbstractMessageModel> models, ArrayList<Uri> shareFileUris, String caption) {
 		if (TestUtil.required(context, models, shareFileUris)) {
 			if (models.size() > 0 && shareFileUris.size() > 0) {
 				Intent intent;
@@ -3060,6 +3060,9 @@ public class MessageServiceImpl implements MessageService {
 					intent.setType(getMimeTypeString(model));
 					if (ContentResolver.SCHEME_CONTENT.equalsIgnoreCase(shareFileUri.getScheme())) {
 						intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+					}
+					if (!TestUtil.empty(caption)) {
+						intent.putExtra(Intent.EXTRA_TEXT, caption);
 					}
 				} else {
 					intent = new Intent(Intent.ACTION_SEND_MULTIPLE);


### PR DESCRIPTION
## Description

When sharing an image, the same dialog will pop up, which is displayed when forwarding an image within Threema.
The user can edit, remove or create a caption so share along with the image.

When multiple images are selected, no dialog will appear and all captions will be omitted.

## Checklist

- [x] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [x] All changes in this pull request were created by me, I own the full copyright
      for all these changes
