### PR TITLE
Editable poll answers (in wizard)

### DIFF
--- a/app/src/main/java/ch/threema/app/activities/ballot/BallotWizardFragment0.java
+++ b/app/src/main/java/ch/threema/app/activities/ballot/BallotWizardFragment0.java
@@ -130,6 +130,9 @@ public class BallotWizardFragment0 extends BallotWizardFragment implements Ballo
 	@Override
 	public void onMissingTitle() {
 		this.textInputLayout.setError(getString(R.string.title_cannot_be_empty));
+		this.editText.setFocusableInTouchMode(true);
+		this.editText.setFocusable(true);
+		this.editText.requestFocus();
 	}
 
 	@Override

--- a/app/src/main/java/ch/threema/app/adapters/ballot/BallotWizard1Adapter.java
+++ b/app/src/main/java/ch/threema/app/adapters/ballot/BallotWizard1Adapter.java
@@ -40,6 +40,7 @@ import ch.threema.storage.models.ballot.BallotChoiceModel;
 public class BallotWizard1Adapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
 	public interface OnChoiceListener {
+		void onEditClicked(int position);
 		void onRemoveClicked(int position);
 	}
 
@@ -47,11 +48,13 @@ public class BallotWizard1Adapter extends RecyclerView.Adapter<RecyclerView.View
 
 		public TextView name;
 		public ImageView removeButton;
+		public ImageView editButton;
 
 		public BallotAdminChoiceItemHolder(@NonNull View itemView) {
 			super(itemView);
 			name = itemView.findViewById(R.id.choice_name_readonly);
 			removeButton = itemView.findViewById(R.id.remove_button);
+			editButton = itemView.findViewById(R.id.edit_button);
 		}
 
 		public void bind(BallotChoiceModel choiceModel, OnChoiceListener onChoiceListener) {
@@ -64,8 +67,15 @@ public class BallotWizard1Adapter extends RecyclerView.Adapter<RecyclerView.View
 						}
 					});
 					removeButton.setVisibility(View.VISIBLE);
+					editButton.setOnClickListener(view -> {
+						if (onChoiceListener != null) {
+							onChoiceListener.onEditClicked(getAdapterPosition());
+						}
+					});
+					editButton.setVisibility(View.VISIBLE);
 				} else {
 					removeButton.setVisibility(View.GONE);
+					editButton.setVisibility(View.GONE);
 				}
 			}
 		}

--- a/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
+++ b/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
@@ -79,10 +79,6 @@ public class ExpandableTextEntryDialog extends ThreemaDialogFragment {
 		return dialog;
 	}
 
-	public void setCallback(ExpandableTextEntryDialogClickListener callback) {
-		this.callback = callback;
-	}
-
 	public interface ExpandableTextEntryDialogClickListener {
 		void onYes(String tag, Object data, String text);
 		void onNo(String tag);

--- a/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
+++ b/app/src/main/java/ch/threema/app/dialogs/ExpandableTextEntryDialog.java
@@ -79,6 +79,10 @@ public class ExpandableTextEntryDialog extends ThreemaDialogFragment {
 		return dialog;
 	}
 
+	public void setCallback(ExpandableTextEntryDialogClickListener callback) {
+		this.callback = callback;
+	}
+
 	public interface ExpandableTextEntryDialogClickListener {
 		void onYes(String tag, Object data, String text);
 		void onNo(String tag);

--- a/app/src/main/java/ch/threema/app/dialogs/TextEntryDialog.java
+++ b/app/src/main/java/ch/threema/app/dialogs/TextEntryDialog.java
@@ -77,6 +77,25 @@ public class TextEntryDialog extends ThreemaDialogFragment {
 	}
 
 	public static TextEntryDialog newInstance(@StringRes int title, @StringRes int message,
+	                                          @StringRes int positive, @StringRes int negative,
+	                                          String text, int inputType, int inputFilterType,
+	                                          int maxLines) {
+		TextEntryDialog dialog = new TextEntryDialog();
+		Bundle args = new Bundle();
+		args.putInt("title", title);
+		args.putInt("message", message);
+		args.putInt("positive", positive);
+		args.putInt("negative", negative);
+		args.putString("text", text);
+		args.putInt("inputType", inputType);
+		args.putInt("inputFilterType", inputFilterType);
+		args.putInt("maxLines", maxLines);
+
+		dialog.setArguments(args);
+		return dialog;
+	}
+
+	public static TextEntryDialog newInstance(@StringRes int title, @StringRes int message,
 	                                          @StringRes int positive, @StringRes int neutral, @StringRes int negative,
 	                                          String text, int inputType, int inputFilterType, int maxLength) {
 		TextEntryDialog dialog = new TextEntryDialog();

--- a/app/src/main/res/layout/item_ballot_choice_vote.xml
+++ b/app/src/main/res/layout/item_ballot_choice_vote.xml
@@ -46,8 +46,6 @@
 			android:layout_marginTop="5dip"
 			android:layout_toLeftOf="@+id/vote_count"
 			android:layout_toRightOf="@id/choice_radio"
-			android:ellipsize="end"
-			android:maxLines="3"
 			android:text="Name"
 			android:textAppearance="?android:attr/textAppearanceSmall"
 			android:textColor="?attr/textColorPrimary" />

--- a/app/src/main/res/layout/item_ballot_wizard1.xml
+++ b/app/src/main/res/layout/item_ballot_wizard1.xml
@@ -25,15 +25,16 @@
 		app:tint="?attr/textColorSecondary" />
 
 	<ch.threema.app.emojis.EmojiConversationTextView
-			android:id="@+id/choice_name_readonly"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:textSize="16sp"
-			android:layout_marginRight="4dp"
-			android:layout_toRightOf="@+id/reorder_button"
-			android:layout_toLeftOf="@+id/edit_button"
-			android:layout_centerVertical="true"
-			android:text="X" />
+		android:id="@+id/choice_name_readonly"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:textSize="16sp"
+		android:layout_marginRight="4dp"
+		android:layout_toRightOf="@+id/reorder_button"
+		android:layout_toLeftOf="@+id/edit_button"
+		android:layout_centerVertical="true"
+		android:text="X"
+		android:singleLine="true"/>
 
 	<ImageView
 		android:id="@+id/edit_button"
@@ -42,7 +43,7 @@
 		android:layout_centerVertical="true"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
-		android:tint="?attr/textColorSecondary"
+		app:tint="?attr/textColorSecondary"
 		android:contentDescription="@string/remove"
 		app:srcCompat="@drawable/ic_pencil_outline" />
 

--- a/app/src/main/res/layout/item_ballot_wizard1.xml
+++ b/app/src/main/res/layout/item_ballot_wizard1.xml
@@ -31,10 +31,20 @@
 			android:textSize="16sp"
 			android:layout_marginRight="4dp"
 			android:layout_toRightOf="@+id/reorder_button"
-			android:layout_toLeftOf="@+id/remove_button"
+			android:layout_toLeftOf="@+id/edit_button"
 			android:layout_centerVertical="true"
-			android:text="X"
-			android:singleLine="true"/>
+			android:text="X" />
+
+	<ImageView
+		android:id="@+id/edit_button"
+		android:layout_marginRight="10dp"
+		android:layout_toLeftOf="@+id/remove_button"
+		android:layout_centerVertical="true"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:tint="?attr/textColorSecondary"
+		android:contentDescription="@string/remove"
+		app:srcCompat="@drawable/ic_pencil_outline" />
 
 	<ImageView
 		android:id="@+id/remove_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1241,5 +1241,6 @@
 	<string name="tap_here_for_more">Tap here for more information</string>
 	<string name="another_connection_instructions">The server has detected two or more connections from different devices with the same Threema ID.\n\nIt is not possible to use the same Threema ID on several devices simultaneously. New messages are only transmitted to the device that last logged in to the server.\n\nIf you\'re switching to a new device, please uninstall or disable %s on the old device and then reboot the new one.</string>
 	<string name="app_store_error_code">App store error code: %d</string>
+	<string name="edit_answer">Edit answer</string>
 </resources>
 


### PR DESCRIPTION
## Description

- Adds an edit button to answers when creating a poll
- Focuses the poll title edit text when the title was missing
- Removes the maxLines restriction for poll answers in the dialog. It's quite bad when you can't read the whole answer before the poll is closed. So I think even when the dialog may become quite big ans you have to scroll a lot, it's worth being able to read the whole answer.

One thing I was wondering about: is there a reason, why the `ExpandableTextEntryDialog` tries to get the callback activity or fragment automatically? I wasn't able to catch the callback inside the fragment. The Dialog tried to invoke the callback on the activity containing the fragment...
Also ` public void onAttach(@NonNull Activity activity)` which is used there is deprecated.

That's why I added the method `setCallback` to pass an `ExpandableTextEntryDialogClickListener` explicitly.

## Checklist

- [X] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [X] All changes in this pull request were made by me, I own the full copyright
      for all these changes
