### PR TITLE
Adds mark as read option to group message notifications

### DIFF
--- a/app/src/main/java/ch/threema/app/services/NotificationServiceImpl.java
+++ b/app/src/main/java/ch/threema/app/services/NotificationServiceImpl.java
@@ -787,7 +787,9 @@ public class NotificationServiceImpl implements NotificationService {
 					.setShowsUserInterface(false).build());
 			}
 
-			if (newestGroup.getMessageReceiver() instanceof ContactMessageReceiver) {
+			if (newestGroup.getMessageReceiver() instanceof GroupMessageReceiver) {
+				builder.addAction(getMarkAsReadAction(markReadPendingIntent));
+			} else if (newestGroup.getMessageReceiver() instanceof ContactMessageReceiver) {
 
 				if (conversationNotification.getMessageType().equals(MessageType.VOIP_STATUS))  {
 					// Create an intent for the call action
@@ -812,11 +814,15 @@ public class NotificationServiceImpl implements NotificationService {
 						builder.addAction(new NotificationCompat.Action.Builder(R.drawable.ic_thumb_up_white_24dp, context.getString(R.string.acknowledge), ackPendingIntent)
 								.setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_THUMBS_UP).build());
 					}
-					builder.addAction(new NotificationCompat.Action.Builder(R.drawable.ic_mark_read, context.getString(R.string.mark_read_short), markReadPendingIntent)
-						.setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MARK_AS_READ).build());
+					builder.addAction(getMarkAsReadAction(markReadPendingIntent));
 				}
 			}
 		}
+	}
+
+	private NotificationCompat.Action getMarkAsReadAction(PendingIntent markReadPendingIntent) {
+		return new NotificationCompat.Action.Builder(R.drawable.ic_mark_read, context.getString(R.string.mark_read_short), markReadPendingIntent)
+			.setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MARK_AS_READ).build();
 	}
 
 	private void createSingleNotification(ConversationNotificationGroup newestGroup,
@@ -1037,7 +1043,7 @@ public class NotificationServiceImpl implements NotificationService {
 			synchronized (this.conversationNotifications) {
 				cancelPinLockedNewMessagesNotification();
 
-				//check if more then one group in the notification
+				//check if more than one group in the notification
 				ConversationNotification newestNotification = null;
 				HashSet<ConversationNotificationGroup> uniqueNotificationGroups = new HashSet<>();
 
@@ -1130,7 +1136,7 @@ public class NotificationServiceImpl implements NotificationService {
 		synchronized (this.conversationNotifications) {
 			cancelPinLockedNewMessagesNotification();
 
-			//check if more then one group in the notification
+			//check if more than one group in the notification
 			ConversationNotificationGroup newestGroup = null;
 			ConversationNotification newestNotification = null;
 			Map<String, ConversationNotificationGroup> uniqueNotificationGroups = new HashMap<>();


### PR DESCRIPTION
## Description
This PR adds the Mark As Read feature to group message notifications.

Since in the latest update the decline message notification action was ditched for private chats in favor of the mark as read action, I think it makes sense to add this option to group chat notificataions as well.

## Checklist

- [x] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [x] All changes in this pull request were made by me, I own the full copyright
      for all these changes
