### PR TITLE
Insert filter from MessageSection into ArchiveActivity automatically

### DIFF
--- a/app/src/main/java/ch/threema/app/ThreemaApplication.java
+++ b/app/src/main/java/ch/threema/app/ThreemaApplication.java
@@ -203,6 +203,7 @@ public class ThreemaApplication extends MultiDexApplication implements DefaultLi
 	public static final String INTENT_DATA_EDITFOCUS = "editfocus";
 	public static final String INTENT_DATA_GROUP = "group";
 	public static final String INTENT_DATA_DISTRIBUTION_LIST = "distribution_list";
+	public static final String INTENT_DATA_ARCHIVE_FILTER = "archiveFilter";
 	public static final String INTENT_DATA_QRCODE = "qrcodestring";
 	public static final String INTENT_DATA_QRCODE_TYPE_OK = "qrcodetypeok";
 	public static final String INTENT_DATA_MESSAGE_ID = "messageid";

--- a/app/src/main/java/ch/threema/app/archive/ArchiveActivity.java
+++ b/app/src/main/java/ch/threema/app/archive/ArchiveActivity.java
@@ -45,6 +45,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import ch.threema.app.R;
+import ch.threema.app.ThreemaApplication;
 import ch.threema.app.activities.ThreemaActivity;
 import ch.threema.app.activities.ThreemaToolbarActivity;
 import ch.threema.app.asynctasks.DeleteConversationsAsyncTask;
@@ -59,6 +60,7 @@ import ch.threema.app.ui.ThreemaSearchView;
 import ch.threema.app.utils.AnimationUtil;
 import ch.threema.app.utils.ConfigUtils;
 import ch.threema.app.utils.IntentDataUtil;
+import ch.threema.app.utils.TestUtil;
 import ch.threema.base.ThreemaException;
 import ch.threema.storage.models.AbstractMessageModel;
 import ch.threema.storage.models.ConversationModel;
@@ -184,6 +186,12 @@ public class ArchiveActivity extends ThreemaToolbarActivity implements GenericAl
 		// Observe the LiveData, passing in this activity as the LifecycleOwner and the observer.
 		viewModel.getConversationModels().observe(this, conversationsObserver);
 		viewModel.onDataChanged();
+
+		String filterQuery = getIntent().getStringExtra(ThreemaApplication.INTENT_DATA_ARCHIVE_FILTER);
+		if (!TestUtil.empty(filterQuery)) {
+			filterMenu.expandActionView();
+			searchView.setQuery(filterQuery, false);
+		}
 
 		return true;
 	}

--- a/app/src/main/java/ch/threema/app/fragments/MessageSectionFragment.java
+++ b/app/src/main/java/ch/threema/app/fragments/MessageSectionFragment.java
@@ -1081,7 +1081,9 @@ public class MessageSectionFragment extends MainFragment
 
 	@Override
 	public void onFooterClick(View view) {
-		AnimationUtil.startActivity(getActivity(), view,  new Intent(getActivity(), ArchiveActivity.class));
+		Intent intent = new Intent(getActivity(), ArchiveActivity.class);
+		intent.putExtra(ThreemaApplication.INTENT_DATA_ARCHIVE_FILTER, filterQuery);
+		AnimationUtil.startActivity(getActivity(), view, intent);
 	}
 
 	private void editGroup(ConversationModel model, View view) {


### PR DESCRIPTION
If you search for a contact in the MessageSection Fragment and then click on the footer the search text is passed into the ArchiveActivity and directly inserted into the search bar there.

IMHO this is what the user is expecting and I would love to see these changes implemented.

- [x] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [x] All changes in this pull request were made by me, I own the full copyright
      for all these changes
