### PR TITLE
Make battery optimizations prompt less confusing.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -835,7 +835,7 @@
     <string name="check_now">Check Now</string>
     <string name="discard">Discard</string>
     <string name="android_backup_restart_threema">Hold on. The app will be restarted in a few seconds.</string>
-    <string name="battery_optimizations_title">Disable Battery Optimizations</string>
+    <string name="battery_optimizations_title">Keep Battery Optimizations Disabled?</string>
     <string name="battery_optimizations_explain">Battery optimization prevents %1$s from working correctly when your phone falls into sleep mode. Please disable battery optimization for %2$s.</string>
     <string name="battery_optimizations_disable_guide">Select “All Apps” in the drop down menu</string>
     <string name="battery_optimizations_disable_guide_ctd">Search for %s in the list and deactivate the optimization</string>


### PR DESCRIPTION
In the current state, the prompt reads:
> Disable Battery Optimizations
> 
> Do you really want to keep battery
> optimization switched on for Threema?
> Desktop/Web will not work correctly.
>
> No Yes

If the user only reads the title and the options, they are going to click the wrong one.

This problem is compounded by the fact that prompt comes right after a similar looking prompt in which the options are "Continue anyway" and "Disable".

This change modifies the title to be a question for which the options are answers that make sense.

An alternative fix would involve keeping the title as is and modify the content and the options. However that requires also modifying all the translations synchronously. With this change, translations can be modified independently.

## Description

<!-- Please describe your change. If the change concerns the user interface,
please include screenshots. For improvements to translation strings
please see CONTRIBUTING.md or README.md -->

## Checklist

<!-- Please check the items that apply. -->

- [ ] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [ ] All changes in this pull request were made by me, I own the full copyright
      for all these changes
