### PR TITLE
search: show search widget immediately, gate filter on message load

### DIFF
--- a/app/src/main/java/ch/threema/app/fragments/composemessage/ComposeMessageFragment.java
+++ b/app/src/main/java/ch/threema/app/fragments/composemessage/ComposeMessageFragment.java
@@ -543,6 +543,11 @@ public class ComposeMessageFragment extends Fragment implements
     private TextView searchCounter;
     private CircularProgressIndicator searchProgress;
     private ImageView searchNextButton, searchPreviousButton;
+    /** True once the message history has finished loading. The search filter is gated on this. */
+    private boolean allMessagesLoaded = false;
+    /** Latest query typed while the history was still loading. Applied once when load finishes. */
+    @Nullable
+    private CharSequence pendingSearchQuery = null;
     private ViewGroup editMessageBubbleContainer;
     private View dimBackground;
     private ComposeView editMessageBubbleComposeView;
@@ -5049,6 +5054,14 @@ public class ComposeMessageFragment extends Fragment implements
         // listener for search bar on top
         @Override
         public boolean onQueryTextChange(String newText) {
+            if (!allMessagesLoaded) {
+                // buffer; filtering a half-loaded list gives wrong results
+                pendingSearchQuery = (newText != null && newText.length() >= MIN_CONSTRAINT_LENGTH) ? newText : null;
+                if (searchProgress != null) {
+                    searchProgress.setVisibility(pendingSearchQuery != null ? View.VISIBLE : View.INVISIBLE);
+                }
+                return true;
+            }
             composeMessageAdapter.getFilter().filter(newText);
             return true;
         }
@@ -5877,12 +5890,6 @@ public class ComposeMessageFragment extends Fragment implements
 
             activity.getMenuInflater().inflate(R.menu.action_compose_message_search, menu);
 
-            final MenuItem item = menu.findItem(R.id.menu_action_search);
-            final View actionView = item.getActionView();
-
-            item.setActionView(R.layout.item_progress);
-            item.expandActionView();
-
             if (bottomPanel != null) {
                 bottomPanel.setVisibility(View.GONE);
             }
@@ -5891,30 +5898,34 @@ public class ComposeMessageFragment extends Fragment implements
             dismissMentionPopup();
             dismissQuotePopup();
 
-            // load all records
+            // configure the search widget synchronously so focus + typing work while
+            // the message list loads in the background
+            final MenuItem searchItem = menu.findItem(R.id.menu_action_search);
+            configureSearchWidget(searchItem);
+
+            // load all records; once they're in, apply any query the user typed during the wait
             new AsyncTask<Void, Void, Void>() {
                 List<AbstractMessageModel> messageModels;
 
                 @Override
                 protected Void doInBackground(Void... params) {
                     messageModels = getAllRecords();
-
                     return null;
                 }
 
                 @Override
                 protected void onPostExecute(Void result) {
                     if (messageModels != null && isAdded()) {
-                        item.collapseActionView();
-                        item.setActionView(actionView);
-                        configureSearchWidget(menu.findItem(R.id.menu_action_search));
-
                         insertToList(messageModels, true, true, true);
                         convListView.setSelection(Integer.MAX_VALUE);
+                        allMessagesLoaded = true;
+                        if (pendingSearchQuery != null) {
+                            composeMessageAdapter.getFilter().filter(pendingSearchQuery);
+                            pendingSearchQuery = null;
+                        }
                     }
                 }
             }.execute();
-
 
             return true;
         }
@@ -5934,6 +5945,8 @@ public class ComposeMessageFragment extends Fragment implements
         public void onDestroyActionMode(ActionMode mode) {
             searchCounter = null;
             searchActionMode = null;
+            allMessagesLoaded = false;
+            pendingSearchQuery = null;
             if (composeMessageAdapter != null) {
                 composeMessageAdapter.clearFilter();
             }


### PR DESCRIPTION
Per my mail exchange with opensource@threema.ch from 09.04.

First of multiple small fixes to in-chat search.

Problem: When you tap the search icon on a long conversation, a loading spinner appears until the app has loaded the full message history (often a few seconds on large chats). From the user's POV it may be confusing as to why anything has to load before any search input was made (unintuitive).

Proposed fix: Configure the `SearchView` synchronously in `onCreateActionMode` so focus and input are available immediately, and move `getAllRecords()` to the background without blocking the UI behind a spinner. When the user finishes typing before the messages are loaded in the background, finish loading messages first, then search. 

This makes more sense from the user's POV: they search for something and then a loading spinner is shown. Whether the app is still loading messages into cache or actually searching is irrelevant.

https://github.com/user-attachments/assets/e5ceb444-a62a-435b-9203-8f107a19ef81

https://github.com/user-attachments/assets/67a8f46d-07a4-4365-b425-98394ba849bc

Please note that threema_new contains a whole bunch of changes (too much work to create a video for each PR), this PR only changes the interaction described above. Other PRs will follow :)

