### PR TITLE
search: in-chat search visual polish

### DIFF
--- a/app/src/main/java/ch/threema/app/fragments/composemessage/ComposeMessageFragment.java
+++ b/app/src/main/java/ch/threema/app/fragments/composemessage/ComposeMessageFragment.java
@@ -543,6 +543,8 @@ public class ComposeMessageFragment extends Fragment implements
     private TextView searchCounter;
     private CircularProgressIndicator searchProgress;
     private ImageView searchNextButton, searchPreviousButton;
+    private volatile boolean isSearchInProgress = false;
+    private int lastSearchResultsSize = 0;
     private ViewGroup editMessageBubbleContainer;
     private View dimBackground;
     private ComposeView editMessageBubbleComposeView;
@@ -3532,17 +3534,14 @@ public class ComposeMessageFragment extends Fragment implements
                     RuntimeUtil.runOnUiThread(() -> {
                         if (searchCounter != null) {
                             try {
+                                lastSearchResultsSize = searchResultsSize;
                                 if (queryLength < MIN_CONSTRAINT_LENGTH && searchResultsSize == 0) {
                                     searchCounter.setText(getString(R.string.min_n_chars, MIN_CONSTRAINT_LENGTH));
-                                    searchCounter.setVisibility(View.VISIBLE);
-                                    searchPreviousButton.setVisibility(View.INVISIBLE);
-                                    searchNextButton.setVisibility(View.INVISIBLE);
                                 } else {
                                     searchCounter.setText(String.format("%d / %d", searchResultsIndex, searchResultsSize));
-                                    searchCounter.setVisibility(View.VISIBLE);
-                                    searchPreviousButton.setVisibility(View.VISIBLE);
-                                    searchNextButton.setVisibility(View.VISIBLE);
                                 }
+                                searchCounter.setVisibility(View.VISIBLE);
+                                updateSearchNavButtonsVisibility();
                             } catch (Exception e) {
                                 //
                             }
@@ -3552,10 +3551,12 @@ public class ComposeMessageFragment extends Fragment implements
 
                 @Override
                 public void onSearchInProgress(boolean inProgress) {
+                    isSearchInProgress = inProgress;
                     RuntimeUtil.runOnUiThread(() -> {
                         if (searchNextButton != null && searchPreviousButton != null) {
                             try {
                                 searchProgress.setVisibility(inProgress ? View.VISIBLE : View.INVISIBLE);
+                                updateSearchNavButtonsVisibility();
                             } catch (Exception e) {
                                 //
                             }
@@ -5832,6 +5833,15 @@ public class ComposeMessageFragment extends Fragment implements
         return this.currentPageReferenceId;
     }
 
+    /** Hides prev/next while a filter runs (the spinner shares their FrameLayout) or when there's nothing to navigate to. */
+    private void updateSearchNavButtonsVisibility() {
+        if (searchPreviousButton != null && searchNextButton != null) {
+            int visibility = !isSearchInProgress && lastSearchResultsSize > 0 ? View.VISIBLE : View.INVISIBLE;
+            searchPreviousButton.setVisibility(visibility);
+            searchNextButton.setVisibility(visibility);
+        }
+    }
+
     private void configureSearchWidget(final MenuItem menuItem) {
         SearchView searchView = (SearchView) menuItem.getActionView();
         if (searchView != null) {
@@ -5848,7 +5858,9 @@ public class ComposeMessageFragment extends Fragment implements
             LinearLayout linearLayoutOfSearchView = (LinearLayout) searchView.getChildAt(0);
             if (linearLayoutOfSearchView != null) {
                 linearLayoutOfSearchView.setGravity(Gravity.CENTER_VERTICAL);
-                linearLayoutOfSearchView.setPadding(0, 0, 0, 0);
+                // 10dp trailing padding so the next-match button sits off the action-bar edge
+                int endPx = (int) (10 * getResources().getDisplayMetrics().density);
+                linearLayoutOfSearchView.setPadding(0, 0, endPx, 0);
 
                 searchCounter = (TextView) layoutInflater.inflate(R.layout.textview_search_action, null);
                 linearLayoutOfSearchView.addView(searchCounter);
@@ -5934,6 +5946,8 @@ public class ComposeMessageFragment extends Fragment implements
         public void onDestroyActionMode(ActionMode mode) {
             searchCounter = null;
             searchActionMode = null;
+            isSearchInProgress = false;
+            lastSearchResultsSize = 0;
             if (composeMessageAdapter != null) {
                 composeMessageAdapter.clearFilter();
             }

--- a/app/src/main/res/layout/button_search_action.xml
+++ b/app/src/main/res/layout/button_search_action.xml
@@ -26,11 +26,11 @@
         android:id="@+id/next_progress"
         android:layout_width="32dp"
         android:layout_height="?attr/actionBarSize"
-        android:maxHeight="24dp"
-        android:maxWidth="24dp"
         android:layout_gravity="left|center_vertical"
         android:gravity="left|center_vertical"
         android:visibility="gone"
-        android:indeterminate="true" />
+        android:indeterminate="true"
+        app:indicatorSize="24dp"
+        app:trackThickness="2dp" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/textview_search_action.xml
+++ b/app/src/main/res/layout/textview_search_action.xml
@@ -6,7 +6,7 @@
     android:gravity="center_vertical|right"
     android:minHeight="?attr/actionBarSize"
     android:minWidth="30dp"
-    android:paddingRight="6dp"
+    android:paddingRight="12dp"
     android:text="0 / 0"
     android:textColor="?attr/colorOnSurface"
     android:textSize="11dp"


### PR DESCRIPTION
Per my mail exchange with opensource@threema.ch from 09.04.

First of multiple small fixes to in-chat search.

Problems:
- Progress spinner looks oversized: `maxWidth`, `maxHeight` are set but don't apply (they size the view but not the indicator content)
- Spinner overlays the next-arrow icon: Doesn't look good. Buttons don't need to be visible while it's loading anyways IMO
- Loading spinner sits against right edge; move off a little bit
- Counter (`22/22`) visually sits slightly closer to ^/v buttons than x button
- Outer left/right paddings weren't equal

before/after
<img width="1344" height="200" alt="bef1" src="https://github.com/user-attachments/assets/d45d0ced-4b29-4121-b2c3-6f04ed786280" />
<img width="1344" height="162" alt="af1" src="https://github.com/user-attachments/assets/dfb78627-d76d-4a1e-a415-a1667944ca17" />

before/after
<img width="1344" height="200" alt="be2" src="https://github.com/user-attachments/assets/d9fcbfc7-c558-4d30-b561-c51539539e30" />
<img width="1344" height="153" alt="af2" src="https://github.com/user-attachments/assets/c1afd620-5c97-42ce-b2ac-4fea0c5c5a34" />

